### PR TITLE
Marshal arbitrary JSON diagnostics and other minor improvemenmts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Current
+
+- remove "start", "stop", and "restart" commands (they were broken)
+- marshal arbitrary JSON to Annotation via use-configurable paths
+- `makeClient` now cleans up its resources correctly
+- Add documentation
+
 # 1.2.0
 
 - Implement LSP client

--- a/package.json
+++ b/package.json
@@ -22,18 +22,6 @@
   "contributes": {
     "commands": [
       {
-        "command": "alloglot.start",
-        "title": "Alloglot: Start"
-      },
-      {
-        "command": "alloglot.stop",
-        "title": "Alloglot: Stop"
-      },
-      {
-        "command": "alloglot.restart",
-        "title": "Alloglot: Restart"
-      },
-      {
         "command": "alloglot.apisearch",
         "title": "Alloglot: Api search"
       }
@@ -55,34 +43,120 @@
           "default": [],
           "items": {
             "type": "object",
+            "required": [
+              "languageId"
+            ],
             "properties": {
               "languageId": {
-                "type": "string",
-                "description": "The unique language ID. You can usually find this in a language's syntax-highlighting extension.",
-                "default": ""
+                "type": "string"
               },
               "serverCommand": {
                 "type": "string",
-                "description": "A command to start the language server.",
-                "default": ""
+                "default": null
               },
               "formatCommand": {
                 "type": "string",
-                "description": "A formatter command. Reads from STDIN and writes to STDOUT. `${file}` will be interpolated with the path to the file.",
-                "default": ""
+                "default": null
               },
               "apiSearchUrl": {
                 "type": "string",
-                "description": "URL to documentation/API search. `${query}` will be interpolated with the symbol under cursor.",
-                "default": ""
+                "default": null
               },
               "annotationsFiles": {
                 "type": "array",
-                "default": [],
+                "default": null,
                 "items": {
-                  "type": "string",
-                  "description": "JSON files that will be polled for diagnostics. See README.md for the format.",
-                  "default": ""
+                  "type": "object",
+                  "required": [
+                    "file",
+                    "format",
+                    "mapping"
+                  ],
+                  "properties": {
+                    "file": {
+                      "type": "string"
+                    },
+                    "format": {
+                      "type": "string"
+                    },
+                    "mapping": {
+                      "type": "object",
+                      "required": [
+                        "message"
+                      ],
+                      "properties": {
+                        "message": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "file": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        },
+                        "startLine": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        },
+                        "startColumn": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        },
+                        "endLine": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        },
+                        "endColumn": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        },
+                        "source": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        },
+                        "severity": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        },
+                        "replacements": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        },
+                        "referenceCode": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": null
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -35,116 +35,162 @@ Portions of this software are derived from [ghcid](https://github.com/ndmitchell
 
 import * as vscode from 'vscode'
 
-import { Config, Elem, alloglot } from "./config";
+import { Annotation, AnnotationsConfig, LanguageConfig, alloglot } from "./config";
 
-export function makeAnnotations(lang: Elem<Config['languages']>): vscode.Disposable {
-  const files = lang.annotationsFiles
-  if (files.length === 0) return { dispose: () => { } }
+export function makeAnnotations(config: LanguageConfig): vscode.Disposable {
+  const { languageId, annotations } = config
+  if (!languageId || !annotations || annotations.length === 0) return vscode.Disposable.from()
 
   const diagnostics = vscode.languages.createDiagnosticCollection(alloglot.collections.annotations)
-  const watchers = files.map(watchAnnotationsFile(diagnostics)).flat()
+  const watchers: Array<vscode.Disposable> = annotations.map(file => watchAnnotationsFile(diagnostics, file))
 
-  const actions = vscode.languages.registerCodeActionsProvider(
-    lang.languageId,
-    { provideCodeActions: (document, range, context) => context.diagnostics.map(asQuickFixes).flat() },
+  const quickFixes = vscode.languages.registerCodeActionsProvider(
+    languageId,
+    { provideCodeActions: (document, range, context) => context.diagnostics.map(utils.asQuickFixes).flat() },
     { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }
   )
 
   return vscode.Disposable.from(
-    actions,
+    quickFixes,
     ...watchers,
     diagnostics
   )
 }
 
-function watchAnnotationsFile(diagnostics: vscode.DiagnosticCollection): (file: string) => vscode.Disposable {
-  return file => {
-    const watchers = vscode.workspace.workspaceFolders?.map(ws => {
-      const pattern = new vscode.RelativePattern(ws, file)
-      const watcher = vscode.workspace.createFileSystemWatcher(pattern, false, false, false)
+function watchAnnotationsFile(diagnostics: vscode.DiagnosticCollection, cfg: AnnotationsConfig): vscode.Disposable {
+  const messagePath = utils.path<string>(cfg.mapping.message)
+  const filePath = utils.path<string>(cfg.mapping.file)
+  const startLinePath = utils.path<number>(cfg.mapping.startLine)
+  const startColumnPath = utils.path<number>(cfg.mapping.startColumn)
+  const endLinePath = utils.path<number>(cfg.mapping.endLine)
+  const endColumnPath = utils.path<number>(cfg.mapping.endColumn)
+  const sourcePath = utils.path<string>(cfg.mapping.source)
+  const severityPath = utils.path<string>(cfg.mapping.severity)
+  const replacementsPath = utils.path<Array<string>>(cfg.mapping.replacements)
+  const referenceCodePath = utils.path<string | number>(cfg.mapping.referenceCode)
 
-      watcher.onDidChange(addAnnotations(diagnostics))
-      watcher.onDidCreate(addAnnotations(diagnostics))
-      watcher.onDidDelete(uri => diagnostics.delete(uri))
+  function marshalAnnotation(json: any): Annotation | undefined {
+    const message = messagePath(json)
+    const file = filePath(json)
+    if (!message || !file) return
 
-      return watcher
-    }) || []
+    const startLine = startLinePath(json) || 0
+    const startColumn = startColumnPath(json) || 0
+    const endLine = endLinePath(json) || startLine
+    const endColumn = endColumnPath(json) || startColumn
 
-    return vscode.Disposable.from(...watchers)
+    return {
+      message, file, startLine, startColumn, endLine, endColumn,
+      source: sourcePath(json) || `${cfg.file}`,
+      severity: utils.parseSeverity(severityPath(json)),
+      replacements: replacementsPath(json) || [],
+      referenceCode: referenceCodePath(json)?.toString(),
+    }
   }
-}
 
-type Annotation = {
-  source: string
-  severity: 'error' | 'warning' | 'info' | 'hint'
-  file: string
-  startLine: number
-  startColumn: number
-  endLine: number
-  endColumn: number
-  message: string
-  replacements: Array<string>
-  referenceCode?: string
-}
+  function readAnnotations(bytes: Uint8Array): Array<Annotation> {
+    const contents = Buffer.from(bytes).toString('utf8')
+    const jsons: Array<any> = cfg.format === 'jsonl'
+      ? contents.split('\n').map(line => JSON.parse(line))
+      : JSON.parse(contents)
+    const annotations = jsons.map(marshalAnnotation).filter(x => x) as Array<Annotation>
+    return annotations
+  }
 
-function addAnnotations(diagnostics: vscode.DiagnosticCollection): (uri: vscode.Uri) => void {
-  return uri => {
+  function annotationsBySourceFile(annotations: Array<Annotation>): Map<string, Array<Annotation>> {
+    const sorted = new Map<string, Array<Annotation>>()
+    annotations.forEach(annotation => {
+      const annotationsForFile = sorted.get(annotation.file)
+      annotationsForFile
+        ? annotationsForFile.push(annotation)
+        : sorted.set(annotation.file, [annotation])
+    })
+    return sorted
+  }
+
+  function addAnnotations(uri: vscode.Uri): void {
     vscode.workspace.fs.readFile(uri).then(bytes => {
-      const annotations: Array<Annotation> = JSON.parse(Buffer.from(bytes).toString('utf8')) || []
-      const sorted: Map<string, Array<Annotation>> = new Map()
-      annotations.forEach(ann => {
-        const current = sorted.get(ann.file)
-        current
-          ? current.push(ann)
-          : sorted.set(ann.file, [ann])
-      })
-      sorted.forEach((anns, path) => {
-        diagnostics.set(vscode.Uri.file(path), anns.map(asDiagnostic))
+      annotationsBySourceFile(readAnnotations(bytes)).forEach((anns, path) => {
+        diagnostics.set(vscode.Uri.file(path), anns.map(utils.annotationAsDiagnostic))
       })
     })
   }
+
+  const watchers = vscode.workspace.workspaceFolders?.map(ws => {
+    const pattern = new vscode.RelativePattern(ws, cfg.file)
+    const watcher = vscode.workspace.createFileSystemWatcher(pattern, false, false, false)
+
+    watcher.onDidChange(addAnnotations)
+    watcher.onDidCreate(addAnnotations)
+    watcher.onDidDelete(diagnostics.delete)
+
+    return watcher
+  }) || []
+
+  return vscode.Disposable.from(...watchers)
 }
 
-function asDiagnostic(ann: Annotation): vscode.Diagnostic {
-  const range = annotationRange(ann)
-  const message = ann.message
-  const severity = asDiagnosticSeverity(ann.severity)
-  const diag = new vscode.Diagnostic(range, message, severity)
-  diag.source = ann.source
-  diag.relatedInformation = annotationRelatedInformation(ann)
-  diag.code = diag.code
-  return diag
-}
+namespace utils {
+  export function annotationAsDiagnostic(ann: Annotation): vscode.Diagnostic {
+    const range = new vscode.Range(
+      new vscode.Position(ann.startLine - 1, ann.startColumn - 1),
+      new vscode.Position(ann.endLine - 1, ann.endColumn - 1)
+    )
 
-function annotationRelatedInformation(ann: Annotation): Array<vscode.DiagnosticRelatedInformation> {
-  const uri = vscode.Uri.file(ann.file)
-  const range = annotationRange(ann)
-  const location = new vscode.Location(uri, range)
-  return ann.replacements.map(message => new vscode.DiagnosticRelatedInformation(location, message))
-}
+    // we are abusing the relatedInformation field to store replacements
+    // we look them up later when we need to create quick fixes
+    const relatedInformation = ann.replacements.map(replacement => {
+      const uri = vscode.Uri.file(ann.file)
+      const location = new vscode.Location(uri, range)
+      return new vscode.DiagnosticRelatedInformation(location, replacement)
+    })
 
-function annotationRange(ann: Annotation): vscode.Range {
-  const start = new vscode.Position(ann.startLine - 1, ann.startColumn - 1)
-  const end = new vscode.Position(ann.endLine - 1, ann.endColumn - 1)
-  return new vscode.Range(start, end)
-}
-
-function asDiagnosticSeverity(sev: Annotation['severity']): vscode.DiagnosticSeverity {
-  switch (sev) {
-    case 'error': return vscode.DiagnosticSeverity.Error
-    case 'warning': return vscode.DiagnosticSeverity.Warning
-    case 'info': return vscode.DiagnosticSeverity.Information
-    case 'hint': return vscode.DiagnosticSeverity.Hint
+    // i wish they gave an all-args constructor
+    const diagnostic = new vscode.Diagnostic(range, ann.message, asDiagnosticSeverity(ann.severity))
+    diagnostic.source = ann.source
+    diagnostic.relatedInformation = relatedInformation
+    diagnostic.code = ann.referenceCode
+    return diagnostic
   }
-}
 
-function asQuickFixes(diag: vscode.Diagnostic): Array<vscode.CodeAction> {
-  const actions = diag.relatedInformation?.map(info => {
-    const action = new vscode.CodeAction(diag.message, vscode.CodeActionKind.QuickFix)
-    action.diagnostics = [diag]
-    action.edit = new vscode.WorkspaceEdit
-    action.edit.replace(info.location.uri, info.location.range, info.message)
-    return action
-  })
-  return actions || []
+  function asDiagnosticSeverity(sev: Annotation['severity']): vscode.DiagnosticSeverity {
+    switch (sev) {
+      case 'error': return vscode.DiagnosticSeverity.Error
+      case 'warning': return vscode.DiagnosticSeverity.Warning
+      case 'info': return vscode.DiagnosticSeverity.Information
+      case 'hint': return vscode.DiagnosticSeverity.Hint
+    }
+  }
+
+  // this depends on the fact that we're abusing the `relatedInformation` field
+  // see `annotationAsDiagnostic` above
+  export function asQuickFixes(diag: vscode.Diagnostic): Array<vscode.CodeAction> {
+    const actions = diag.relatedInformation?.map(info => {
+      const action = new vscode.CodeAction(diag.message, vscode.CodeActionKind.QuickFix)
+      action.diagnostics = [diag]
+      action.edit = new vscode.WorkspaceEdit
+      action.edit.replace(info.location.uri, info.location.range, info.message)
+      return action
+    })
+    return actions || []
+  }
+
+  export function path<T>(keys: Array<string> | undefined): (json: any) => T | undefined {
+    if (!keys) return () => undefined
+    else return json => {
+      const result = keys.reduce((acc, key) => acc?.[key], json)
+      if (result) return result as T
+      else return
+    }
+  }
+
+  export function parseSeverity(raw: string | undefined): Annotation['severity'] {
+    if (!raw) return 'error'
+    const lower = raw.toLowerCase()
+    if (lower.includes('error')) return 'error'
+    if (lower.includes('warning')) return 'warning'
+    if (lower.includes('info')) return 'info'
+    if (lower.includes('hint')) return 'hint'
+    return 'error'
+  }
 }

--- a/src/apisearch.ts
+++ b/src/apisearch.ts
@@ -209,9 +209,11 @@ import * as vscode from 'vscode'
 import { Config, alloglot } from './config'
 
 export function makeApiSearch(config: Config): vscode.Disposable {
-  const langs: Map<string, string> = new Map()
+  const { languages } = config
+  if (languages.length === 0) return vscode.Disposable.from()
 
-  config.languages.forEach(lang => {
+  const langs: Map<string, string> = new Map()
+  languages.forEach(lang => {
     lang.languageId && lang.apiSearchUrl && langs.set(lang.languageId, lang.apiSearchUrl)
   })
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,17 +2,21 @@ import * as child_process from 'child_process'
 import * as vscode from 'vscode'
 import * as lsp from 'vscode-languageclient/node'
 
-import { Config, Elem, alloglot } from './config'
+import { LanguageConfig, alloglot } from './config'
 
-export function makeClient(config: Elem<Config['languages']>): vscode.Disposable {
-  if (!config.languageId || !config.serverCommand) return vscode.Disposable.from()
+/**
+ * A full-featured generic LSP client.
+ * The client launches its own server in a child process and cleans up after itself.
+ */
+export function makeClient(config: LanguageConfig): vscode.Disposable {
+  const { languageId, serverCommand } = config
+  if (!languageId || !serverCommand) return vscode.Disposable.from()
 
-  const clientId = `${alloglot.root}-${config.languageId}`
+  const clientId = `${alloglot.root}-${languageId}`
   const output = vscode.window.createOutputChannel(clientId)
-  const server = child_process.spawn(config.serverCommand, [], { env: process.env })
 
   const clientOptions = {
-    documentSelector: [{ scheme: 'file', language: config.languageId }],
+    documentSelector: [{ scheme: 'file', language: languageId }],
     synchronize: { configurationSection: alloglot.root },
     revealOutputChannelOn: lsp.RevealOutputChannelOn.Never,
     outputChannel: output,
@@ -20,21 +24,46 @@ export function makeClient(config: Elem<Config['languages']>): vscode.Disposable
     workspaceFolder: vscode.workspace.workspaceFolders?.[0]
   }
 
-  let client = new lsp.LanguageClient(
-    clientId,
-    `${alloglot.root} language client for ${config.languageId}`,
-    () => Promise.resolve(server),
-    clientOptions,
-    false
-  )
-
-  client.start()
-
-  return vscode.Disposable.from({
-    dispose: () => {
-      client.stop()
-      server.kill()
-      output.dispose()
+  return utils.bracket<child_process.ChildProcessWithoutNullStreams, vscode.Disposable>({
+    open: () => child_process.spawn(serverCommand, [], { env: process.env }),
+    close: server => server.kill(),
+    use: server => {
+      return utils.bracket<lsp.LanguageClient, vscode.Disposable>({
+        open: () => {
+          let client = new lsp.LanguageClient(
+            clientId,
+            `${alloglot.root} language client for ${languageId}`,
+            () => Promise.resolve(server),
+            clientOptions,
+            false
+          )
+          client.start()
+          return client
+        },
+        close: client => client.stop(),
+        use: client => {
+          return vscode.Disposable.from({
+            dispose: () => {
+              client.stop()
+              server.kill()
+              output.dispose()
+            }
+          })
+        }
+      })
     }
   })
+}
+
+namespace utils {
+  export function bracket<T, U>(args: { open: () => T, close: (t: T) => void, use: (t: T) => U }): U {
+    let t: T | undefined = undefined
+    try {
+      t = args.open()
+      return args.use(t)
+    }
+    finally {
+      if (t) args.close(t)
+    }
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,99 @@
-export type Elem<as extends Array<unknown>> = as extends Array<infer a> ? a : never
-
+/**
+ * Extension configuration.
+ */
 export type Config = {
-  languages: Array<{
-    languageId: string
-    serverCommand: string
-    formatCommand: string
-    apiSearchUrl: string
-    annotationsFiles: Array<string>
-  }>
+  /**
+   * An array of per-language configurations.
+   */
+  languages: Array<LanguageConfig>
+}
+
+/**
+ * Configuration for an arbitrary language.
+ */
+export type LanguageConfig = {
+  /**
+   * The unique language ID.
+   * You can usually find this in a language's syntax-highlighting extension.
+   */
+  languageId: string
+
+  /**
+   * A command to start the language server.
+   */
+  serverCommand?: string
+
+  /**
+   * A formatter command.
+   * Reads from STDIN and writes to STDOUT.
+   * `${file}` will be interpolated with the path to the file.
+   */
+  formatCommand?: string
+
+  /**
+   * URL to documentation/API search.
+   * `${query}` will be interpolated with the symbol under cursor.
+   */
+  apiSearchUrl?: string
+
+  /**
+   * A list of files to watch for compiler-generated JSON output.
+   */
+  annotations?: Array<AnnotationsConfig>
+}
+
+/**
+ * A file to watch for compiler-generated JSON output, and instructions on how to marshal the JSON objects.
+ */
+export type AnnotationsConfig = {
+  /**
+   * The path to the file to watch.
+   */
+  file: string
+
+  /**
+   * `json` for a top-level array of objects.
+   * `jsonl` for a newline-separated stream of objects.
+   */
+  format: 'json' | 'jsonl'
+
+  /**
+   * Mapping between properties of the JSON objects and properties of `Annotation`.
+   */
+  mapping: AnnotationsMapping
+}
+
+/**
+ * Intermediate representation of compiler-generated JSON output and VS Code diagnostics.
+ */
+export type Annotation = {
+  source: string
+  severity: 'error' | 'warning' | 'info' | 'hint'
+  file: string
+  startLine: number
+  startColumn: number
+  endLine: number
+  endColumn: number
+  message: string
+  replacements: Array<string>
+  referenceCode?: string
+}
+
+/**
+ * Mapping between arbitrary JSON object and properties of `Annotation`.
+ * Each property is an array of strings that will be used as a path into the JSON object.
+ */
+export type AnnotationsMapping = {
+  message: Array<string>
+  file?: Array<string>
+  startLine?: Array<string>
+  startColumn?: Array<string>
+  endLine?: Array<string>
+  endColumn?: Array<string>
+  source?: Array<string>
+  severity?: Array<string>
+  replacements?: Array<string>
+  referenceCode?: Array<string>
 }
 
 export namespace alloglot {


### PR DESCRIPTION
This is a backwards-incompatible change.

* remove "start", "stop", and "restart" commands (they were broken)
* marshal arbitrary JSON to Annotation via use-configurable paths
* `makeClient` now cleans up its resources correctly
* Add documentation
* refactor for maintainance