### PR TITLE
Fix stderr bug in formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "alloglot" extension will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adhere's to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2024-02-07
+
+- Fix bug in document formatter that prevented text edits if the formatter logs to stderr.
+- Add output channel for formatter.
+
 ## [2.1.0] - 2024-02-01
 
 - Fix bug in annotations file paths.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "commands": [
       {
         "command": "alloglot.apisearch",
-        "title": "Alloglot: Api search"
+        "title": "Goto documentation"
       }
     ],
     "menus": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -26,7 +26,7 @@ export function makeClient(config: LanguageConfig): vscode.Disposable {
     debug: serverExecutable
   }
 
-  const clientId = `${alloglot.root}-${languageId}`
+  const clientId = `${alloglot.root}-${languageId}-client}`
   const output = vscode.window.createOutputChannel(clientId)
 
   const clientOptions = {


### PR DESCRIPTION
The formatter had an error that would suppress document text edits when the format child process wrote anything to stderr, e.g. logs.