### PR TITLE
Add activation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adhere's to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [unreleased]
 
+- Add activation command.
+
+## [2.4.0]
+
 - Centralized output channel.
 - Reload config and restart extension when config changes.
 - Add `initTagsCommand` and `refreshTagsCommand` to `TagsConfig`.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ Most of the properties are optional, so you can make use of only the features th
 
 ```json
 {
+  "alloglot.activationCommand": "ghcid",
   "alloglot.languages": [
     {
+      "languageId": "cabal",
+      "formatCommand": "cabal-fmt --stdout",
+      "apiSearchUrl": "https://hoogle.haskell.org/?hoogle=${query}"
+    },
+    {
       "languageId": "haskell",
-      "activationCommand": "ghcid",
       "serverCommand": "static-ls",
       "formatCommand": "fourmolu --mode stdout --stdin-input-file ${file}",
       "apiSearchUrl": "https://hoogle.haskell.org/?hoogle=${query}",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Most of the properties are optional, so you can make use of only the features th
   "alloglot.languages": [
     {
       "languageId": "haskell",
+      "activationCommand": "ghcid",
       "serverCommand": "static-ls",
       "formatCommand": "fourmolu --mode stdout --stdin-input-file ${file}",
       "apiSearchUrl": "https://hoogle.haskell.org/?hoogle=${query}",
@@ -101,6 +102,13 @@ export type Config = {
    * An array of per-language configurations.
    */
   languages: Array<LanguageConfig>
+
+  /**
+   * A shell command to run on activation.
+   * The command will run asynchronously.
+   * It will be killed (if it's still running) on deactivation.
+   */
+  activateCommand?: string
 }
 
 /**

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -36,7 +36,8 @@ Portions of this software are derived from [ghcid](https://github.com/ndmitchell
 import { dirname } from 'path'
 import * as vscode from 'vscode'
 
-import { Annotation, AnnotationsConfig, HierarchicalOutputChannel, LanguageConfig, alloglot } from "./config";
+import { Annotation, AnnotationsConfig, LanguageConfig, alloglot } from './config'
+import { HierarchicalOutputChannel } from './utils'
 
 export function makeAnnotations(output: HierarchicalOutputChannel, config: LanguageConfig): vscode.Disposable {
   output.appendLine('Starting annotations...')

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -37,9 +37,9 @@ import { dirname } from 'path'
 import * as vscode from 'vscode'
 
 import { Annotation, AnnotationsConfig, LanguageConfig, alloglot } from './config'
-import { HierarchicalOutputChannel } from './utils'
+import { IHierarchicalOutputChannel } from './utils'
 
-export function makeAnnotations(output: HierarchicalOutputChannel, config: LanguageConfig): vscode.Disposable {
+export function makeAnnotations(output: IHierarchicalOutputChannel, config: LanguageConfig): vscode.Disposable {
   output.appendLine('Starting annotations...')
   const { languageId, annotations } = config
   if (!languageId || !annotations || annotations.length === 0) return vscode.Disposable.from()

--- a/src/apisearch.ts
+++ b/src/apisearch.ts
@@ -206,7 +206,8 @@ Portions of this software are derived from [vscode-goto-documentation](https://g
 
 import * as vscode from 'vscode'
 
-import { Config, HierarchicalOutputChannel, alloglot } from './config'
+import { Config, alloglot } from './config'
+import { HierarchicalOutputChannel } from './utils'
 
 export function makeApiSearch(output: HierarchicalOutputChannel, config: Config): vscode.Disposable {
   const { languages } = config

--- a/src/apisearch.ts
+++ b/src/apisearch.ts
@@ -207,9 +207,9 @@ Portions of this software are derived from [vscode-goto-documentation](https://g
 import * as vscode from 'vscode'
 
 import { Config, alloglot } from './config'
-import { HierarchicalOutputChannel } from './utils'
+import { IHierarchicalOutputChannel } from './utils'
 
-export function makeApiSearch(output: HierarchicalOutputChannel, config: Config): vscode.Disposable {
+export function makeApiSearch(output: IHierarchicalOutputChannel, config: Config): vscode.Disposable {
   const { languages } = config
   if (languages.length === 0) return vscode.Disposable.from()
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode'
 import * as lsp from 'vscode-languageclient/node'
 
-import { HierarchicalOutputChannel, LanguageConfig, alloglot } from './config'
+import { LanguageConfig, alloglot } from './config'
+import { HierarchicalOutputChannel } from './utils'
 
 /**
  * A full-featured generic LSP client.

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,13 +2,13 @@ import * as vscode from 'vscode'
 import * as lsp from 'vscode-languageclient/node'
 
 import { LanguageConfig, alloglot } from './config'
-import { HierarchicalOutputChannel } from './utils'
+import { IHierarchicalOutputChannel } from './utils'
 
 /**
  * A full-featured generic LSP client.
  * The client launches its own server in a child process and cleans up after itself.
  */
-export function makeClient(output: HierarchicalOutputChannel, config: LanguageConfig): vscode.Disposable {
+export function makeClient(output: IHierarchicalOutputChannel, config: LanguageConfig): vscode.Disposable {
   const { languageId, serverCommand } = config
   if (!languageId || !serverCommand) return vscode.Disposable.from()
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,37 +3,39 @@ import * as vscode from 'vscode'
 import { makeAnnotations } from './annotations'
 import { makeApiSearch } from './apisearch'
 import { makeClient } from './client'
-import { Config, HierarchicalOutputChannel, alloglot } from './config'
+import { Config, alloglot } from './config'
 import { makeFormatter } from './formatter'
 import { makeTags } from './tags'
+import { AsyncProcess, HierarchicalOutputChannel } from './utils'
 
 let globalOutput: vscode.OutputChannel | undefined
 let globalContext: vscode.ExtensionContext | undefined
 
 export function activate(context: vscode.ExtensionContext): void {
+  if (globalOutput) {
+    globalOutput.dispose()
+    globalOutput = undefined
+  }
+
   globalContext = context
   const output = HierarchicalOutputChannel.make(alloglot.root)
-  output.appendLine('Starting Alloglot...')
   globalOutput = output
-  const config = Config.create()
-  output.appendLine(`Loaded configuration:\n${JSON.stringify(config, null, 2)}`)
+  output.show(true)
+
+  output.appendLine('Starting Alloglot...')
+  const config = Config.make()
+  output.appendLine(`Using configuration:\n${JSON.stringify(config, null, 2)}`)
 
   context.subscriptions.push(
+    // Start the activation command if it's configured.
+    makeActivationCommand(output, config.activateCommand),
     // Make a single API search command because VSCode can't dynamically create commands.
     makeApiSearch(output.local(alloglot.components.apiSearch), config),
-    // But we can dynamically create diagnostics sets...
-    ...config.languages.map(lang => makeAnnotations(output.local(alloglot.components.annotations).local(lang.languageId), lang)),
-    // ...dynamically register language formatting providers...
-    ...config.languages.map(lang => makeFormatter(output.local(alloglot.components.formatter).local(lang.languageId), lang)),
-    // ...dynamically create LSP clients
-    ...config.languages.map(lang => makeClient(output.local(alloglot.components.client).local(lang.languageId), lang)),
-    // ...and dynamically create completions, definitions, and code actions providers.
-    ...config.languages.map(lang => makeTags(output.local(alloglot.components.tags).local(lang.languageId), lang)),
-    // restart extension when config changes
-    vscode.workspace.onDidChangeConfiguration(ev => {
-      if (ev.affectsConfiguration(alloglot.config.root)) restart(output, context)
-    }),
-    // user command to restart extension
+    ...config.languages.map(lang => makeAnnotations(output.local(`${alloglot.components.annotations}-${lang.languageId}`), lang)),
+    ...config.languages.map(lang => makeFormatter(output.local(`${alloglot.components.formatter}-${lang.languageId}`), lang)),
+    ...config.languages.map(lang => makeClient(output.local(`${alloglot.components.client}-${lang.languageId}`), lang)),
+    ...config.languages.map(lang => makeTags(output.local(`${alloglot.components.tags}-${lang.languageId}`), lang)),
+    vscode.workspace.onDidChangeConfiguration(ev => ev.affectsConfiguration(alloglot.config.root) && restart(output, context)),
     vscode.commands.registerCommand(alloglot.commands.restart, () => restart(output, context)),
   )
 }
@@ -51,4 +53,10 @@ function restart(output?: vscode.OutputChannel, context?: vscode.ExtensionContex
   output && output.appendLine('Restarting Alloglot...')
   disposeAll(output, context)
   context && activate(context)
+}
+
+function makeActivationCommand(output: HierarchicalOutputChannel, command: string | undefined): vscode.Disposable {
+  if (!command) return vscode.Disposable.from()
+  const basedir = vscode.workspace.workspaceFolders?.[0].uri
+  return AsyncProcess.make({ output, command, basedir }, () => {})
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { makeClient } from './client'
 import { Config, alloglot } from './config'
 import { makeFormatter } from './formatter'
 import { makeTags } from './tags'
-import { AsyncProcess, HierarchicalOutputChannel } from './utils'
+import { AsyncProcess, HierarchicalOutputChannel, IHierarchicalOutputChannel } from './utils'
 
 let globalOutput: vscode.OutputChannel | undefined
 let globalContext: vscode.ExtensionContext | undefined
@@ -55,7 +55,7 @@ function restart(output?: vscode.OutputChannel, context?: vscode.ExtensionContex
   context && activate(context)
 }
 
-function makeActivationCommand(output: HierarchicalOutputChannel, command: string | undefined): vscode.Disposable {
+function makeActivationCommand(output: IHierarchicalOutputChannel, command: string | undefined): vscode.Disposable {
   if (!command) return vscode.Disposable.from()
   const basedir = vscode.workspace.workspaceFolders?.[0].uri
   return AsyncProcess.make({ output, command, basedir }, () => {})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,82 @@
+import { exec } from 'child_process'
+import * as vscode from 'vscode'
+
+interface AsyncProcess<T> extends vscode.Disposable, Promise<T> { }
+
+export namespace AsyncProcess {
+  type Spec = {
+    output: vscode.OutputChannel
+    command: string
+    basedir?: vscode.Uri
+    stdin?: string
+  }
+
+  export function make<T>(spec: Spec, f: (stdout: string) => T): AsyncProcess<T> {
+    let controller: AbortController | undefined = new AbortController()
+    const { signal } = controller
+
+    const { output, command, basedir, stdin } = spec
+    const cwd = basedir?.fsPath
+
+    // giving this an `any` signature allows us to add a `dispose` method.
+    // it's a little bit jank, but i don't know how else to do it.
+    const asyncProc: any = new Promise((resolve, reject) => {
+      output.appendLine(`Running '${command}' in '${cwd}'...`)
+
+      const proc = exec(command, { cwd, signal }, (error, stdout, stderr) => {
+        if (error) {
+          output.appendLine(`Error running '${command}':\n\t${error}`)
+          reject(error)
+        }
+
+        stderr && output.appendLine(`Logs from '${command}':\n\t${stderr}`)
+        !stdout && output.appendLine(`Received no output from '${command}'.`)
+
+        resolve(f(stdout))
+      })
+
+      stdin && proc.stdin?.write(stdin)
+      proc.stdin?.end()
+      output.appendLine(`Ran '${command}'.`)
+    })
+
+    asyncProc['dispose'] = () => {
+      // ensure that calling `dispose()` a second time is a no-op
+      if (controller) {
+        output.appendLine(`Killing '${command}'...`)
+        controller.abort()
+        controller = undefined
+        output.appendLine(`Killed '${command}'.`)
+      }
+    }
+
+    return asyncProc as AsyncProcess<T>
+  }
+}
+
+export interface HierarchicalOutputChannel extends vscode.OutputChannel {
+  prefixPath: Array<string>
+  local(prefix: string): HierarchicalOutputChannel
+}
+
+export namespace HierarchicalOutputChannel {
+  export function make(name: string): HierarchicalOutputChannel {
+    return promote([], vscode.window.createOutputChannel(name))
+  }
+
+  function addPrefix(output: vscode.OutputChannel, prefix: string): vscode.OutputChannel {
+    return {
+      ...output,
+      append: (value: string) => output.append(`[${prefix}] ${value}`),
+      appendLine: (value: string) => output.appendLine(`[${prefix}] ${value}`)
+    }
+  }
+
+  function promote(prefixPath: Array<string>, output: vscode.OutputChannel): HierarchicalOutputChannel {
+    return {
+      ...output,
+      prefixPath,
+      local: (prefix: string) => promote([...prefixPath, prefix], addPrefix(output, prefix)) // this part was a PITA to figure out :-p
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `activationCommand` to alloglot config. This can be used to do things such as starting ghcid or running hpack.