### PR TITLE
Multiple tags files (and other improvements)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ This project adhere's to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [unreleased]
 
-- Configure path to `grep`.
+- Support configurable path to `grep`.
+- Support multiple tags configs. `alloglot.tags` must now be an array of `TagsConfig`.
+- Support merging workspace config with fallback config.
+- Some error handling and reporting for configs.
 
 ## [2.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "alloglot" extension will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adhere's to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+- Configure path to `grep`.
+
 ## [2.6.0]
 
 - Add `deactivateCommand` to `TConfig` to run on extension `deactivate()`

--- a/package.json
+++ b/package.json
@@ -51,23 +51,27 @@
       "properties": {
         "alloglot.activateCommand": {
           "type": "string",
-          "description": "A shell command to run on activation. The command will run asynchronously. It will be killed (if it's still running) on deactivation.",
-          "default": null
+          "description": "A shell command to run on activation. The command will run asynchronously. It will be killed (if it's still running) on deactivation."
         },
         "alloglot.deactivateCommand": {
           "type": "string",
-          "description": "A shell command to run on deactivation.",
-          "default": null
+          "description": "A shell command to run on deactivation."
         },
         "alloglot.verboseOutput": {
           "type": "boolean",
-          "description": "If `true`, Alloglot will log more output.",
-          "default": null
+          "description": "If `true`, Alloglot will log more output."
+        },
+        "alloglot.mergeConfigs": {
+          "type": "boolean",
+          "description": "If `true`, Alloglot will merge `.vscode/alloglot.json` into its config."
+        },
+        "alloglot.grepPath": {
+          "type": "string",
+          "description": "Path to GNU Grep. Parsing tags files depends on GNU Grep. (BSD Grep is not supported.)"
         },
         "alloglot.languages": {
           "type": "array",
           "description": "An array of language configurations. See README.md for schema.",
-          "default": null,
           "items": {
             "type": "object",
             "required": [
@@ -78,79 +82,74 @@
                 "type": "string"
               },
               "serverCommand": {
-                "type": "string",
-                "default": null
+                "type": "string"
               },
               "formatCommand": {
-                "type": "string",
-                "default": null
+                "type": "string"
               },
               "apiSearchUrl": {
-                "type": "string",
-                "default": null
+                "type": "string"
               },
               "tags": {
-                "type": "object",
-                "default": null,
-                "required": [
-                  "file",
-                  "grepPath"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string"
-                  },
-                  "grepPath": {
-                    "type": "string"
-                  },
-                  "initTagsCommand": {
-                    "type": "string"
-                  },
-                  "refreshTagsCommand": {
-                    "type": "string"
-                  },
-                  "completionsProvider": {
-                    "type": "boolean"
-                  },
-                  "definitionsProvider": {
-                    "type": "boolean"
-                  },
-                  "importsProvider": {
-                    "type": "object",
-                    "required": [
-                      "importLinePattern",
-                      "matchFromFilepath",
-                      "renderModuleName"
-                    ],
-                    "properties": {
-                      "importLinePattern": {
-                        "type": "string"
-                      },
-                      "matchFromFilepath": {
-                        "type": "string"
-                      },
-                      "renderModuleName": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "required": [
-                            "tag"
-                          ],
-                          "properties": {
-                            "tag": {
-                              "type": "string"
-                            },
-                            "from": {
-                              "type": "string"
-                            },
-                            "to": {
-                              "type": "string"
-                            },
-                            "on": {
-                              "type": "string"
-                            },
-                            "with": {
-                              "type": "string"
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "file"
+                  ],
+                  "properties": {
+                    "file": {
+                      "type": "string"
+                    },
+                    "initTagsCommand": {
+                      "type": "string"
+                    },
+                    "refreshTagsCommand": {
+                      "type": "string"
+                    },
+                    "completionsProvider": {
+                      "type": "boolean"
+                    },
+                    "definitionsProvider": {
+                      "type": "boolean"
+                    },
+                    "importsProvider": {
+                      "type": "object",
+                      "required": [
+                        "importLinePattern",
+                        "matchFromFilepath",
+                        "renderModuleName"
+                      ],
+                      "properties": {
+                        "importLinePattern": {
+                          "type": "string"
+                        },
+                        "matchFromFilepath": {
+                          "type": "string"
+                        },
+                        "renderModuleName": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "tag"
+                            ],
+                            "properties": {
+                              "tag": {
+                                "type": "string"
+                              },
+                              "from": {
+                                "type": "string"
+                              },
+                              "to": {
+                                "type": "string"
+                              },
+                              "on": {
+                                "type": "string"
+                              },
+                              "with": {
+                                "type": "string"
+                              }
                             }
                           }
                         }
@@ -159,9 +158,8 @@
                   }
                 }
               },
-              "annotationsFiles": {
+              "annotations": {
                 "type": "array",
-                "default": null,
                 "items": {
                   "type": "object",
                   "required": [
@@ -192,64 +190,55 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         },
                         "startLine": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         },
                         "startColumn": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         },
                         "endLine": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         },
                         "endColumn": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         },
                         "source": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         },
                         "severity": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         },
                         "replacements": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         },
                         "referenceCode": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "default": null
+                          }
                         }
                       }
                     }

--- a/package.json
+++ b/package.json
@@ -93,10 +93,14 @@
                 "type": "object",
                 "default": null,
                 "required": [
-                  "file"
+                  "file",
+                  "grepPath"
                 ],
                 "properties": {
                   "file": {
+                    "type": "string"
+                  },
+                  "grepPath": {
                     "type": "string"
                   },
                   "initTagsCommand": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,11 @@ export type TagsConfig = {
   file: string
 
   /**
+   * Path to GNU Grep. (BSD Grep is not supported.)
+   */
+  grepPath: string
+
+  /**
    * A command to generate the tags file.
    */
   initTagsCommand?: string
@@ -227,7 +232,6 @@ export namespace Config {
     return {
       activateCommand: config.activateCommand?.trim(),
       deactivateCommand: config.deactivateCommand?.trim(),
-      verboseOutput: !!config.verboseOutput,
       languages: config.languages?.filter(lang => {
         // make sure no fields are whitespace-only
         // we mutate the original object because typescript doesn't have a `filterMap` function
@@ -244,6 +248,7 @@ export namespace Config {
 
         if (lang.tags) {
           lang.tags.file = lang.tags.file.trim()
+          lang.tags.grepPath = lang.tags.grepPath.trim()
           lang.tags.initTagsCommand = lang.tags.initTagsCommand?.trim()
           lang.tags.refreshTagsCommand = lang.tags.refreshTagsCommand?.trim()
           if (!lang.tags?.importsProvider?.importLinePattern.trim()) lang.tags.importsProvider = undefined
@@ -265,7 +270,8 @@ export namespace alloglot {
     export const addImport = (moduleName: string) => `Add import: ${moduleName}`
     export const annotationsStarted = 'Annotations started.'
     export const appliedEdit = (success: boolean) => `Applied edit: ${success}`
-    export const applyingTransformations = (t: any, x: string) => `Applying ${JSON.stringify(t)} to ${x}`
+    export const applyingTransformation = (t: any, xs: Array<string>) => `Applying single transformation ${JSON.stringify(t)} to split string array ${xs}`
+    export const applyingTransformations = (t: any, x: string) => `Applying transformations ${JSON.stringify(t)} to string ${x}`
     export const commandKilled = (cmd: string) => `Killed “${cmd}”.`
     export const commandLogs = (cmd: string, logs: string) => `Logs from “${cmd}”:\n\t${logs}`
     export const commandNoOutput = (cmd: string) => `Received no output from “${cmd}”.`

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -3,14 +3,14 @@ import * as vscode from 'vscode'
 import { LanguageConfig, StringTransformation, TagsConfig, alloglot } from './config'
 import { AsyncProcess, Disposal, IAsyncProcess, IHierarchicalOutputChannel } from './utils'
 
-export function makeTags(output: IHierarchicalOutputChannel, config: LanguageConfig, verboseOutput: boolean): vscode.Disposable {
+export function makeTags(output: IHierarchicalOutputChannel, grepPath: string, config: LanguageConfig, verboseOutput: boolean): vscode.Disposable {
   const { languageId, tags } = config
   if (!languageId || !tags || tags.length === 0) return vscode.Disposable.from()
-  return vscode.Disposable.from(...tags.map(tag => makeTag(output, languageId, tag, verboseOutput)))
+  return vscode.Disposable.from(...tags.map(tag => makeTag(output.local(tag.file), grepPath, languageId, tag, verboseOutput)))
 }
 
-function makeTag(output: IHierarchicalOutputChannel, languageId: string, cfg: TagsConfig, verboseOutput: boolean): vscode.Disposable {
-  const { file, grepPath, completionsProvider, definitionsProvider, importsProvider, initTagsCommand, refreshTagsCommand } = cfg
+function makeTag(output: IHierarchicalOutputChannel, grepPath: string, languageId: string, cfg: TagsConfig, verboseOutput: boolean): vscode.Disposable {
+  const { file, completionsProvider, definitionsProvider, importsProvider, initTagsCommand, refreshTagsCommand } = cfg
 
   const basedir: vscode.Uri | undefined = vscode.workspace.workspaceFolders?.[0].uri
   const tagsUri: vscode.Uri | undefined = basedir && vscode.Uri.joinPath(basedir, file)
@@ -21,7 +21,7 @@ function makeTag(output: IHierarchicalOutputChannel, languageId: string, cfg: Ta
 
   output.appendLine(alloglot.ui.startingTags)
   const tagsSourceOutput = verboseOutput ? output.local(alloglot.components.tagsSource).split() : undefined
-  const tagsSource = TagsSource.make({ languageId, grepPath: grepPath || 'grep', basedir, tagsUri, output: tagsSourceOutput, initTagsCommand, refreshTagsCommand })
+  const tagsSource = TagsSource.make({ languageId, grepPath, basedir, tagsUri, output: tagsSourceOutput, initTagsCommand, refreshTagsCommand })
 
   const disposal = Disposal.make()
   disposal.insert(tagsSource)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,10 +72,14 @@ export namespace AsyncProcess {
 
     asyncProc.dispose = () => {
       if (controller) {
-        output?.appendLine(alloglot.ui.killingCommand(command))
-        controller.abort()
-        controller = undefined // ensure `dispose()` is idempotent
-        output?.appendLine(alloglot.ui.commandKilled(command))
+        try {
+          output?.appendLine(alloglot.ui.killingCommand(command))
+          controller.abort()
+          controller = undefined // ensure `dispose()` is idempotent
+          output?.appendLine(alloglot.ui.commandKilled(command))
+        } catch (err) {
+          output?.appendLine(alloglot.ui.errorKillingCommand(command, err))
+        }
       }
     }
 


### PR DESCRIPTION
Co-requisite with https://github.com/MercuryTechnologies/mercury-web-backend/pull/26568

* [DUX-2035](https://linear.app/mercury/issue/DUX-2035/symlink-required-cli-tools): Configure `grep` path.
* [DUX-2037](https://linear.app/mercury/issue/DUX-2037/support-merging-of-workspace-settings-and-vscodealloglotjson): Support merging of workspace and fallback config.
* [DUX-2041](https://linear.app/mercury/issue/DUX-2041/support-multiple-tags-configs): Support multiple tags files.