### PR TITLE
DUX-2027

### DIFF
--- a/src/activationcommand.ts
+++ b/src/activationcommand.ts
@@ -13,5 +13,11 @@ export function makeActivationCommand(parentOutput: IHierarchicalOutputChannel, 
     parentOutput.appendLine(alloglot.ui.activateCommandDone(command))
   })
 
+  proc.catch(err => {
+    vscode.window
+      .showErrorMessage<'Ignore' | 'Restart'>(alloglot.ui.activateCommandFailed(err), 'Ignore', 'Restart')
+      .then(choice => choice === 'Restart' && vscode.commands.executeCommand(alloglot.commands.restart))
+  })
+
   return vscode.Disposable.from(proc, output)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -359,6 +359,7 @@ export namespace alloglot {
 
   export namespace ui {
     export const activateCommandDone = (cmd: string) => `Activation command “${cmd}” has completed.`
+    export const activateCommandFailed = (err: any) => `Activation command has failed: ${err}\n\nIgnore the failure or restart Alloglot?`
     export const addImport = (moduleName: string) => `Add import: ${moduleName}`
     export const annotationsStarted = 'Annotations started.'
     export const appliedEdit = (success: boolean) => `Applied edit: ${success}`


### PR DESCRIPTION
Give user the option to restart Alloglot when startup command fails.

This patch will bring up a VS Code dialogue box when the startup command fails. it will give them the option to ignore the failure or restart alloglot.