### PR TITLE
[DUX-2058] Fix bug in use of child_process

### DIFF
--- a/src/activationcommand.ts
+++ b/src/activationcommand.ts
@@ -9,7 +9,9 @@ export function makeActivationCommand(parentOutput: IHierarchicalOutputChannel, 
   const output = parentOutput.split()
   reveal && output.show(true)
 
-  const proc = AsyncProcess.make({ output, command, basedir }, () => {
+  const proc = AsyncProcess.spawn({ output, command, basedir })
+
+  proc.then(() => () => {
     parentOutput.appendLine(alloglot.ui.activateCommandDone(command))
   })
 

--- a/src/activationcommand.ts
+++ b/src/activationcommand.ts
@@ -13,5 +13,11 @@ export function makeActivationCommand(parentOutput: IHierarchicalOutputChannel, 
     parentOutput.appendLine(alloglot.ui.activateCommandDone(command))
   })
 
+  proc.catch(err => {
+    vscode.window
+      .showErrorMessage<'Ignore' | 'Restart'>(alloglot.ui.activateCommandFailed(err), 'Ignore', 'Restart')
+      .then(choice => choice === 'Restart' && vscode.commands.executeCommand(alloglot.commands.restart))
+  })
+
   return vscode.Disposable.from(proc, output)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -359,6 +359,7 @@ export namespace alloglot {
 
   export namespace ui {
     export const activateCommandDone = (cmd: string) => `Activation command “${cmd}” has completed.`
+    export const activateCommandFailed = (err: any) => `Activation command has failed: ${err}\n\nIgnore the failure or restart Alloglot?`
     export const addImport = (moduleName: string) => `Add import: ${moduleName}`
     export const annotationsStarted = 'Annotations started.'
     export const appliedEdit = (success: boolean) => `Applied edit: ${success}`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ export function deactivate(): Promise<void> {
   }
 
   if (command) {
-    return AsyncProcess.make({ output: globalOutput, command, basedir }, () => undefined)
+    return AsyncProcess.exec({ output: globalOutput, command, basedir }, () => undefined)
       .then(() => {
         globalOutput?.appendLine(alloglot.ui.deactivateCommandDone(command))
         return cleanup()

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -51,7 +51,7 @@ export function makeFormatter(output: vscode.OutputChannel, config: LanguageConf
           document.lineAt(document.lineCount - 1).rangeIncludingLineBreak.end,
         );
 
-        const proc = AsyncProcess.make(
+        const proc = AsyncProcess.exec(
           { output: verboseOutput ? output : undefined, command, basedir, stdin },
           stdout => [new vscode.TextEdit(entireDocument, stdout)]
         )

--- a/src/onsaverunner.ts
+++ b/src/onsaverunner.ts
@@ -17,7 +17,7 @@ export function makeOnSaveRunner(output: vscode.OutputChannel, config: LanguageC
     const refreshTags = (doc: vscode.TextDocument) => {
       if (doc.languageId === languageId) {
         const command = onSaveCommand.replace('${file}', doc.fileName)
-        disposal.insert(AsyncProcess.make({ output, command, basedir }, () => undefined))
+        disposal.insert(AsyncProcess.exec({ output, command, basedir }, () => undefined))
       }
     }
 

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -229,7 +229,7 @@ namespace TagsSource {
 
     if (initTagsCommand) {
       const command = initTagsCommand
-      disposal.insert(AsyncProcess.make({ output, command, basedir }, () => undefined))
+      disposal.insert(AsyncProcess.exec({ output, command, basedir }, () => undefined))
     }
 
     const onSaveWatcher = (() => {
@@ -238,7 +238,7 @@ namespace TagsSource {
       const refreshTags = (doc: vscode.TextDocument) => {
         if (doc.languageId === languageId) {
           const command = refreshTagsCommand.replace('${file}', doc.fileName)
-          disposal.insert(AsyncProcess.make({ output, command, basedir }, () => undefined))
+          disposal.insert(AsyncProcess.exec({ output, command, basedir }, () => undefined))
         }
       }
 
@@ -274,7 +274,7 @@ namespace TagsSource {
     const command = `${grepPath} -P '${regexp.source}' ${tagsUri.fsPath} | head -n ${limit}`
 
     output?.appendLine(`Searching for ${regexp} in ${tagsUri.fsPath}...`)
-    return AsyncProcess.make({ output, command, basedir }, stdout => filterMap(stdout.split('\n'), line => parseTag(line, output)))
+    return AsyncProcess.exec({ output, command, basedir }, stdout => filterMap(stdout.split('\n'), line => parseTag(line, output)))
   }
 
   function parseTag(line: string, output?: vscode.OutputChannel): Tag | undefined {


### PR DESCRIPTION
We currently use `child_process.exec` to capture `stdout` so that it can be processed as one big string. This works great for short-lived CLI utilities, but when used with a long-lived daemon (such as when used with `activateCommand`) the stdout from the long-lived process overfills a buffer, causing the process to fail.

This patch changed the `activateCommand` to use `child_process.spawn` while still preserving the use of `child_process.exec` for everything else.